### PR TITLE
chore(ci): delete default scope

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,6 @@ inputs:
     default: master
   scope:
     description: Platform Test Suite scope
-    default: platform
 runs:
   using: composite
   steps:


### PR DESCRIPTION
#3 incorrectly introduced a default `platform` scope. This PR removes it.

If the scope is not defined, then `e2e` and `functional` will be used, i.e. all the tests.